### PR TITLE
Update run.sh to use updated CLI flag format

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -14,4 +14,4 @@
 ## Examples of other valid options; For more, please view the user guide
 ### java -jar RepoSense.jar --repos https://github.com/reposense/RepoSense.git
 
-java -jar RepoSense.jar --config ./configs -since 01/12/2018
+java -jar RepoSense.jar --config ./configs --since 01/12/2018

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,6 @@
 # Executes RepoSense
 # Do not change the default output folder name (reposense-report)
 ## Examples of other valid options; For more, please view the user guide
-### java -jar RepoSense.jar -repos https://github.com/reposense/RepoSense.git
+### java -jar RepoSense.jar --repos https://github.com/reposense/RepoSense.git
 
-java -jar RepoSense.jar -config ./configs -since 01/12/2018
+java -jar RepoSense.jar --config ./configs -since 01/12/2018


### PR DESCRIPTION
Update run.sh as the CLI flag format has been changed after https://github.com/reposense/RepoSense/pull/526